### PR TITLE
Maintenance change: Update i_dir_acl to i_size_high

### DIFF
--- a/libext2/ext2_utils.c
+++ b/libext2/ext2_utils.c
@@ -156,7 +156,7 @@ int ext2_get_inode(ext2_VOLUME* volume,
         }
 	inode->i_generation = __le32_to_cpu(le_inode->i_generation);
 	inode->i_file_acl = __le32_to_cpu(le_inode->i_file_acl);
-	inode->i_dir_acl = __le32_to_cpu(le_inode->i_dir_acl);
+	inode->i_size_high = __le32_to_cpu(le_inode->i_size_high);
 	inode->i_faddr = __le32_to_cpu(le_inode->i_faddr);
 #ifdef CONFIG_E2FSLIBS
 	inode->osd2.linux2.l_i_blocks_hi =


### PR DESCRIPTION
The former macro has long since been removed from upstream, causing build failures on modern tools. This was fixed in ext4magic all the way back in 2018, for example.

See here: https://sourceforge.net/p/ext4magic/tickets/10/