### PR TITLE
Remove erroneous scripts/tools.sh reference from main makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,8 +367,7 @@ clean:: libemile-clean libmacos-clean libunix-clean tools-clean first-clean \
 	      multiboot.bin
 
 DISTFILES = AUTHORS ChangeLog COPYING Makefile README README.floppy \
-	    README.scsi Rules.mk config/floppy.conf kernel.mk config.mk \
-	    scripts/tools.sh
+	    README.scsi Rules.mk config/floppy.conf kernel.mk config.mk
 
 dist:
 	rm -fr $(PACKAGE)-$(VERSION)


### PR DESCRIPTION
This file has not existed in the repository since 2017, which means attempting to make dist will fail with an error for it being missing. This removes the reference to that file, allowing make dist to succeed.

Considering configure has to be run first (and is what tools.sh became back in 2017), I do not expect the complete omission of this reference to cause any issues.