### PR TITLE
Remove the sp register from UNPRESERVED_REGS

### DIFF
--- a/libmacos/macos/traps.h
+++ b/libmacos/macos/traps.h
@@ -36,7 +36,7 @@
 /*
  * Inside Macintosh Volume I, I-94: Register Saving Conventions */
 
-#define UNPRESERVED_REGS	"%%a0", "%%a1", "%%a2", "%%d1", "%%d2", "%%sp", "memory"
+#define UNPRESERVED_REGS	"%%a0", "%%a1", "%%a2", "%%d1", "%%d2", "memory"
 
 #define _Trap(a)	#a
 #define Trap(a)		"	dc.w	"_Trap(a)"	/* "#a" */\n"


### PR DESCRIPTION
Including the stack pointer register in a clobber list has long since been deprecated by GCC (~9.0 and ~8.4), and according to my research, it appears the compiler ignores its presence in a clobber list regardless.

Whether this is the correct thing to do here I do not know, but from my research, it seems to be, and it does silence the associated deprecation warning that, due to -Werror, causes builds to fail.

See here: https://stackoverflow.com/questions/64928418/arm-cortex-m0-set-msp-c17-compiler-warning